### PR TITLE
Add -r (--reldir) option

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -7,7 +7,7 @@ var minimist = require('minimist');
 
 var argv = minimist(process.argv.slice(2), {
     alias: {
-        i: 'infile', o: 'outfile', b: 'basedir', h: 'help',
+        i: 'infile', o: 'outfile', b: 'basedir', h: 'help', r: 'reldir',
         ignoreImages: 'ignore-images',
         ignoreScripts: 'ignore-scripts',
         ignoreStyles: 'ignore-styles',

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var path = require('path');
 module.exports = function (opts) {
     if (!opts) opts = {};
     var basedir = opts.basedir || process.cwd();
+    var reldir = opts.reldir || basedir;
     var tr = trumpet();
 
     if (!(opts.ignoreScripts || opts['ignore-scripts'])) {
@@ -49,7 +50,7 @@ module.exports = function (opts) {
         if(path.isAbsolute(p)) {
             return path.resolve(basedir, path.relative('/', p));
         } else {
-            return path.resolve(basedir, p);
+            return path.resolve(reldir, p);
         }
     }
     function enc (s) {


### PR DESCRIPTION
To use different directory for relative paths.

I had a problem to inline file that uses both relative and absolute paths.
For it I needed to specify `-b` option and also directory for relative paths so I added option `-r` (`--reldir`) to resolve it.

If `reldir` option is not provided it will fallback to `basedir` to be backwards compatible with previous befavior.