### PR TITLE
inline amp style tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,21 @@ module.exports = function (opts) {
             r.on('end', function () { w.end('</style>') });
         });
     }
+    if (!(opts.ignoreAmp || opts['ignore-amp'])) {
+        tr.selectAll('style[href]', function (node) {
+            var amp = node.getAttribute('amp-custom')
+            if (rel !== 'stylesheet') {
+                consolr.error("amp tag is invalid")
+                return;
+            };
+            var file = fix(node.getAttribute('href'));
+            var w = node.createWriteStream({ outer: true });
+            w.write('<style amp-custom>');
+            var r = fs.createReadStream(file);
+            r.pipe(w, { end: false });
+            r.on('end', function () { w.end('</style>') });
+        });
+    }
 
     return tr;
 

--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ module.exports = function (opts) {
     if (!(opts.ignoreAmp || opts['ignore-amp'])) {
         tr.selectAll('style[href]', function (node) {
             var amp = node.getAttribute('amp-custom')
-            if (rel !== 'stylesheet') {
-                consolr.error("amp tag is invalid")
+            if (!amp) {
+                console.error('amp tag is invalid');
                 return;
             };
             var file = fix(node.getAttribute('href'));

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:soy-curd/html-inline.git"
+    "url": "git@github.com:soy-curd/html-inline-amp.git"
   },
-  "homepage": "https://github.com/soy-curd/html-inline",
+  "homepage": "https://github.com/soy-curd/html-inline-amp",
   "keywords": [
     "html",
     "inline",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "html-inline",
-  "version": "1.2.0",
-  "description": "inline javascript, stylehseets, and images from an html page",
+  "name": "html-inline-amp",
+  "version": "1.2.1",
+  "description": "inline javascript, stylehseets, and images from an html page for amp",
   "main": "index.js",
   "bin": {
     "html-inline": "bin/cmd.js"
@@ -20,18 +20,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/substack/html-inline.git"
+    "url": "git@github.com:soy-curd/html-inline.git"
   },
-  "homepage": "https://github.com/substack/html-inline",
+  "homepage": "https://github.com/soy-curd/html-inline",
   "keywords": [
     "html",
     "inline",
     "asset"
   ],
   "author": {
-    "name": "James Halliday",
-    "email": "mail@substack.net",
-    "url": "http://substack.net"
+    "name": "Soy Curd",
+    "email": "soycurd1@gmail.com",
+    "url": "http://soy-curd.hatenablog.com"
   },
   "license": "MIT"
 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -58,6 +58,7 @@ html-inline {-i INFILE -o OUTFILE -b BASEDIR}
   --ignore-scripts Don't inline JavaScript. Default: false
   --ignore-styles  Don't inline CSS. Default: false
   --ignore-links   Don't inline <link> tags. Default: false
+  --ignore-amp     Don't inline <style amp-custom> tags. Default: false
 
 ```
 
@@ -81,6 +82,7 @@ You can disable asset inlining by passing `true` for:
 * `opts.ignoreScripts`
 * `opts.ignoreStyles`
 * `opts.ignoreLinks`
+* `opts.ignoreAmp`
 
 # install
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,7 @@
-# html-inline
+# html-inline-amp
 
-inline javascript, stylesheets, and images from an html page
+inline javascript, stylesheets, and images from an html page and amp page
+(forked from https://github.com/substack/html-inline)
 
 [![build status](https://secure.travis-ci.org/substack/html-inline.png)](http://travis-ci.org/substack/html-inline)
 

--- a/test/files/expected-amp.html
+++ b/test/files/expected-amp.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+    <style amp-custom>body {
+  background-color: cyan;
+}
+
+.hey {
+  color: red;
+}
+</style>
+  <body>
+    <h1 class="hey">
+        Hey!
+    </h1>
+  </body>
+</html>

--- a/test/files/index-amp.html
+++ b/test/files/index-amp.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <style amp-custom href="./yo-amp.css"></style>
+  <body>
+    <h1 class="hey">
+        Hey!
+    </h1>
+  </body>
+</html>

--- a/test/files/yo-amp.css
+++ b/test/files/yo-amp.css
@@ -1,0 +1,7 @@
+body {
+  background-color: cyan;
+}
+
+.hey {
+  color: red;
+}

--- a/test/inline.js
+++ b/test/inline.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var concat = require('concat-stream');
 var initial = fs.readFileSync(__dirname + '/files/index.html', 'utf8');
 var expected = fs.readFileSync(__dirname + '/files/expected.html', 'utf8');
+var expectedAmp = fs.readFileSync(__dirname + '/files/expected-amp.html', 'utf8');
 var expectedIgnoreImages = fs.readFileSync(__dirname + '/files/expected-ignore-images.html', 'utf8');
 var expectedIgnoreScripts = fs.readFileSync(__dirname + '/files/expected-ignore-scripts.html', 'utf8');
 var expectedIgnoreStyles = fs.readFileSync(__dirname + '/files/expected-ignore-styles.html', 'utf8');
@@ -16,6 +17,15 @@ test('inline', function (t) {
     r.pipe(inline).pipe(concat(function (body) {
         t.equal(body.toString('utf8'), expected);
     }));
+});
+
+test('inline-amp', function (t) {
+  t.plan(1);
+  var inline = inliner({ basedir: __dirname + '/files' });
+  var r = fs.createReadStream(__dirname + '/files/index-amp.html');
+  r.pipe(inline).pipe(concat(function (body) {
+      t.equal(body.toString('utf8'), expectedAmp);
+  }));
 });
 
 test('ignore-images', function (t) {


### PR DESCRIPTION
amp use `<style amp-custom>` tag. (https://www.ampproject.org). 

The implementation is to inline external css file to amp custom tag. 